### PR TITLE
rtu broadcasts ok now

### DIFF
--- a/asciiclient.go
+++ b/asciiclient.go
@@ -203,3 +203,7 @@ func (sf *ASCIIClientProvider) SendRawFrame(aduRequest []byte) (aduResponse []by
 	sf.Debugf("received [% x]", aduResponse)
 	return aduResponse, nil
 }
+
+func (sf *ASCIIClientProvider) SendBroadcast(request ProtocolDataUnit) error {
+	return nil
+}

--- a/client.go
+++ b/client.go
@@ -331,10 +331,14 @@ func (sf *client) WriteSingleRegister(slaveID byte, address, value uint16) error
 		return fmt.Errorf("modbus: slaveID '%v' must be between '%v' and '%v'",
 			slaveID, AddressBroadCast, sf.addressMax)
 	}
-	response, err := sf.Send(slaveID, ProtocolDataUnit{
+	pdu := ProtocolDataUnit{
 		FuncCode: FuncCodeWriteSingleRegister,
 		Data:     uint162Bytes(address, value),
-	})
+	}
+	if 0 == slaveID {
+		return sf.SendBroadcast(pdu)
+	}
+	response, err := sf.Send(slaveID, pdu)
 
 	switch {
 	case err != nil:

--- a/client.go
+++ b/client.go
@@ -382,10 +382,14 @@ func (sf *client) WriteMultipleRegistersBytes(slaveID byte, address, quantity ui
 		return fmt.Errorf("modbus: value length '%v' does not twice as quantity '%v'", len(value), quantity)
 	}
 
-	response, err := sf.Send(slaveID, ProtocolDataUnit{
+	pdu := ProtocolDataUnit{
 		FuncCode: FuncCodeWriteMultipleRegisters,
 		Data:     pduDataBlockSuffix(value, address, quantity),
-	})
+	}
+	if 0 == slaveID {
+		return sf.SendBroadcast(pdu)
+	}
+	response, err := sf.Send(slaveID, pdu)
 
 	switch {
 	case err != nil:

--- a/client_test.go
+++ b/client_test.go
@@ -48,17 +48,17 @@ func Test_client_ReadCoils(t *testing.T) {
 		want    []byte
 		wantErr bool
 	}{
-		{"slaveid不在范围1-247", &provider{},
+		{"slaveid Out of range 不在范围1-247", &provider{},
 			args{slaveID: 248}, nil, true},
-		{"Quantity不在范围1-2000", &provider{},
+		{"Quantity Out of range 不在范围1-2000", &provider{},
 			args{slaveID: 1, quantity: 20001}, nil, true},
-		{"返回error", &provider{err: errors.New("error")},
+		{"return 返回 error", &provider{err: errors.New("error")},
 			args{slaveID: 1, quantity: 10}, nil, true},
-		{"返回数据长度不符", &provider{data: []byte{0x02, 0x00, 0x00, 0x00}},
+		{"Return data length does not match 返回数据长度不符", &provider{data: []byte{0x02, 0x00, 0x00, 0x00}},
 			args{slaveID: 1, quantity: 10}, nil, true},
-		{"返回字节与请求数量不符", &provider{data: []byte{0x01, 0x00}},
+		{"The returned bytes do not match the requested number 返回字节与请求数量不符", &provider{data: []byte{0x01, 0x00}},
 			args{slaveID: 1, quantity: 10}, nil, true},
-		{"正确", &provider{data: []byte{0x02, 0x12, 0x34}},
+		{"correct 正确", &provider{data: []byte{0x02, 0x12, 0x34}},
 			args{slaveID: 1, quantity: 10}, []byte{0x12, 0x34}, false},
 	}
 	for _, tt := range tests {
@@ -89,17 +89,17 @@ func Test_client_ReadDiscreteInputs(t *testing.T) {
 		want    []byte
 		wantErr bool
 	}{
-		{"slaveid不在范围1-247", &provider{},
+		{"slaveid Out of range 不在范围1-247", &provider{},
 			args{slaveID: 248}, nil, true},
-		{"Quantity不在范围1-2000", &provider{},
+		{"Quantity Out of range 不在范围1-2000", &provider{},
 			args{slaveID: 1, quantity: 20001}, nil, true},
-		{"返回error", &provider{err: errors.New("error")},
+		{"return 返回 error", &provider{err: errors.New("error")},
 			args{slaveID: 1, quantity: 10}, nil, true},
-		{"返回数据长度不符", &provider{data: []byte{0x01, 0x00, 0x00}},
+		{"Return data length does not match 返回数据长度不符", &provider{data: []byte{0x01, 0x00, 0x00}},
 			args{slaveID: 1, quantity: 10}, nil, true},
-		{"返回字节与请求数量不符", &provider{data: []byte{0x01, 0x00}},
+		{"The returned bytes do not match the requested number 返回字节与请求数量不符", &provider{data: []byte{0x01, 0x00}},
 			args{slaveID: 1, quantity: 10}, nil, true},
-		{"正确", &provider{data: []byte{0x02, 0x12, 0x34}},
+		{"correct 正确", &provider{data: []byte{0x02, 0x12, 0x34}},
 			args{slaveID: 1, quantity: 10}, []byte{0x12, 0x34}, false},
 	}
 	for _, tt := range tests {

--- a/modbus.go
+++ b/modbus.go
@@ -207,6 +207,9 @@ type ClientProvider interface {
 	// SendRawFrame send raw frame to the remote server
 	SendRawFrame(aduRequest []byte) (aduResponse []byte, err error)
 
+	// SendBroadcast sends request to the remote server(s).
+	SendBroadcast(request ProtocolDataUnit) error
+
 	// private interface
 	// setLogProvider set logger provider
 	setLogProvider(p LogProvider)

--- a/register.go
+++ b/register.go
@@ -1,5 +1,6 @@
 package modbus
 
+// This document provides the low-level encapsulation of the register, and it is thread-safe, and the rich api meets the basic needs
 // 本文件提供了寄存器的底层封装,并且是线程安全的,丰富的api满足基本需求
 
 import (

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	BaudRate = 9600
+	BaudRate = 9600 // modbusInterFrameDelay needs that
 )
 
 const (

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -149,7 +149,13 @@ func (sf *RTUClientProvider) SendRawFrameBroadcast(aduRequest []byte) (err error
 	// In Windows the serial buffer could send its data more quickly, so this delay must
 	// be significantly more than an inter frame delay to avoid violation of modbus timing rules.
 	// see also // https://stackoverflow.com/questions/20740012/calculating-modbus-rtu-3-5-character-time
-	time.Sleep(20 * time.Millisecond)
+
+	// worst case: 11 bit @1200 baud plus interframe delay
+	// 1 byte ^= 916 us -> 1ms
+	// plus 4 ms
+	// better to use sf.serial.Config.BaudRate
+	ms := 4 + len(aduRequest)
+	time.Sleep(time.Duration(ms) * time.Millisecond)
 	return
 }
 

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -149,7 +149,7 @@ func (sf *RTUClientProvider) SendRawFrameBroadcast(aduRequest []byte) (err error
 	if err != nil {
 		sf.close()
 	}
-	time.Sleep(modbusInterFrameDelay())
+	time.Sleep(4 * modbusInterFrameDelay()) // double the time, because for some reason the real distance is smaller than modbusInterFrameDelay()
 	return
 }
 
@@ -280,5 +280,5 @@ func modbusInterFrameDelay() time.Duration {
 	if BaudRate > 19200 {
 		return 1750 * us
 	}
-	return 35000000 * us / time.Duration(BaudRate)
+	return 38500000 * us / time.Duration(BaudRate)
 }

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -349,3 +349,7 @@ func (sf *TCPClientProvider) flush(b []byte) (err error) {
 	}
 	return
 }
+
+func (sf *TCPClientProvider) SendBroadcast(request ProtocolDataUnit) error {
+	return nil
+}

--- a/tcpserver_special.go
+++ b/tcpserver_special.go
@@ -37,19 +37,19 @@ type OnKeepAliveHandler func(c *TCPServerSpecial)
 // TCPServerSpecial modbus tcp server special
 type TCPServerSpecial struct {
 	ServerSession
-	server    *url.URL // 连接的服务器端
+	server    *url.URL // Server side of the connection 连接的服务器端
 	TLSConfig *tls.Config
 	rwMux     sync.RWMutex
-	status    uint32 // 状态
+	status    uint32 // status 状态
 
-	autoReconnect     bool                    // 是否启动重连
-	enableKeepAlive   bool                    // 是否使能心跳包
-	connectTimeout    time.Duration           // 连接超时时间
-	reconnectInterval time.Duration           // 重连间隔时间
-	keepAliveInterval time.Duration           // 心跳包间隔
-	onConnect         OnConnectHandler        // 连接回调
-	onConnectionLost  OnConnectionLostHandler // 失连回调
-	onKeepAlive       OnKeepAliveHandler      // 保活函数
+	autoReconnect     bool                    // Whether to start reconnection 是否启动重连
+	enableKeepAlive   bool                    // Whether to enable the heartbeat packet	是否使能心跳包
+	connectTimeout    time.Duration           // Connection timeout 连接超时时间
+	reconnectInterval time.Duration           // Reconnection interval 重连间隔时间
+	keepAliveInterval time.Duration           // Heartbeat interval 心跳包间隔
+	onConnect         OnConnectHandler        // Connection callback 连接回调
+	onConnectionLost  OnConnectionLostHandler // Lost connection callback 失连回调
+	onKeepAlive       OnKeepAliveHandler      // Keep-alive function 保活函数
 	cancel            context.CancelFunc      // cancel
 }
 
@@ -170,7 +170,7 @@ func (sf *TCPServerSpecial) Start() error {
 	return nil
 }
 
-// 增加间隔
+// Increase interval 增加间隔
 func (sf *TCPServerSpecial) run() {
 	var ctx context.Context
 
@@ -237,6 +237,7 @@ func (sf *TCPServerSpecial) run() {
 		case <-ctx.Done():
 			return
 		default:
+			// Random retry of 500ms-1s to avoid many invalid connections caused by fast retry
 			// 随机500ms-1s的重试，避免快速重试造成服务器许多无效连接
 			time.Sleep(time.Millisecond * time.Duration(500+rand.Intn(500)))
 		}


### PR DESCRIPTION
To compute an exact inter frame delay based on the current baudrate is without sense on a non-realtime system. A fixed 20 ms delay after an rtu broadcast works fine and should be acceptable for good performance.