### PR TITLE
Make tcpclient TCP timeout setter public

### DIFF
--- a/tcpclient.go
+++ b/tcpclient.go
@@ -330,7 +330,7 @@ func (sf *TCPClientProvider) Close() (err error) {
 
 func (sf *TCPClientProvider) setSerialConfig(serial.Config) {}
 
-func (sf *TCPClientProvider) setTCPTimeout(t time.Duration) {
+func (sf *TCPClientProvider) SetTCPTimeout(t time.Duration) {
 	sf.timeout = t
 }
 


### PR DESCRIPTION
While timeout feature have correctly been implemented on tcpclient.go, we're not currently able to change the default value (1s) to anything else because all accesser are private !

I really need to extend or reduce this timeout without needing to fork the project.

If this PR is too naive please comment & I'll be OK to write a more detailled code change.

Thanks a lot